### PR TITLE
Add OPNsense and HP Aruba configuration

### DIFF
--- a/infra/kytkin.pcc
+++ b/infra/kytkin.pcc
@@ -1,0 +1,42 @@
+; J9774A Configuration Editor; Created on release #YA.16.08.0002
+; Ver #14:01.44.00.04.19.02.13.98.82.34.61.18.28.f3.84.9c.63.ff.37.27:45
+hostname "HP-2530-8G-PoEP"
+ip default-gateway 192.168.1.1
+interface 1
+   no power-over-ethernet
+   exit
+interface 2
+   no power-over-ethernet
+   exit
+interface 3
+   no power-over-ethernet
+   exit
+interface 4
+   no power-over-ethernet
+   exit
+interface 5
+   no power-over-ethernet
+   exit
+interface 6
+   no power-over-ethernet
+   exit
+interface 7
+   no power-over-ethernet
+   exit
+interface 8
+   no power-over-ethernet
+   exit
+snmp-server community "public" unrestricted
+vlan 1
+   name "DEFAULT_VLAN"
+   no untagged 1-8
+   untagged 9-10
+   ip address dhcp-bootp
+   exit
+vlan 2
+   name "koneet"
+   untagged 1-8
+   tagged 10
+   no ip address
+   exit
+

--- a/infra/opnsense.xml
+++ b/infra/opnsense.xml
@@ -1,0 +1,1145 @@
+<?xml version="1.0"?>
+<opnsense>
+  <theme>opnsense</theme>
+  <sysctl>
+    <item>
+      <descr>Increase UFS read-ahead speeds to match the state of hard drives and NCQ.</descr>
+      <tunable>vfs.read_max</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Set the ephemeral port range to be lower.</descr>
+      <tunable>net.inet.ip.portrange.first</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Drop packets to closed TCP ports without returning a RST</descr>
+      <tunable>net.inet.tcp.blackhole</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Do not send ICMP port unreachable messages for closed UDP ports</descr>
+      <tunable>net.inet.udp.blackhole</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Randomize the ID field in IP packets</descr>
+      <tunable>net.inet.ip.random_id</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>
+        Source routing is another way for an attacker to try to reach non-routable addresses behind your box.
+        It can also be used to probe for information about your internal networks. These functions come enabled
+        as part of the standard FreeBSD core system.
+      </descr>
+      <tunable>net.inet.ip.sourceroute</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>
+        Source routing is another way for an attacker to try to reach non-routable addresses behind your box.
+        It can also be used to probe for information about your internal networks. These functions come enabled
+        as part of the standard FreeBSD core system.
+      </descr>
+      <tunable>net.inet.ip.accept_sourceroute</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>
+        This option turns off the logging of redirect packets because there is no limit and this could fill
+        up your logs consuming your whole hard drive.
+      </descr>
+      <tunable>net.inet.icmp.log_redirect</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Drop SYN-FIN packets (breaks RFC1379, but nobody uses it anyway)</descr>
+      <tunable>net.inet.tcp.drop_synfin</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Enable sending IPv6 redirects</descr>
+      <tunable>net.inet6.ip6.redirect</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Enable privacy settings for IPv6 (RFC 4941)</descr>
+      <tunable>net.inet6.ip6.use_tempaddr</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Prefer privacy addresses and use them over the normal addresses</descr>
+      <tunable>net.inet6.ip6.prefer_tempaddr</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Generate SYN cookies for outbound SYN-ACK packets</descr>
+      <tunable>net.inet.tcp.syncookies</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Maximum incoming/outgoing TCP datagram size (receive)</descr>
+      <tunable>net.inet.tcp.recvspace</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Maximum incoming/outgoing TCP datagram size (send)</descr>
+      <tunable>net.inet.tcp.sendspace</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Do not delay ACK to try and piggyback it onto a data packet</descr>
+      <tunable>net.inet.tcp.delayed_ack</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Maximum outgoing UDP datagram size</descr>
+      <tunable>net.inet.udp.maxdgram</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Handling of non-IP packets which are not passed to pfil (see if_bridge(4))</descr>
+      <tunable>net.link.bridge.pfil_onlyip</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Set to 1 to additionally filter on the physical interface for locally destined packets</descr>
+      <tunable>net.link.bridge.pfil_local_phys</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Set to 0 to disable filtering on the incoming and outgoing member interfaces.</descr>
+      <tunable>net.link.bridge.pfil_member</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Set to 1 to enable filtering on the bridge interface</descr>
+      <tunable>net.link.bridge.pfil_bridge</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Allow unprivileged access to tap(4) device nodes</descr>
+      <tunable>net.link.tap.user_open</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Randomize PID's (see src/sys/kern/kern_fork.c: sysctl_kern_randompid())</descr>
+      <tunable>kern.randompid</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Disable CTRL+ALT+Delete reboot from keyboard.</descr>
+      <tunable>hw.syscons.kbd_reboot</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Enable TCP extended debugging</descr>
+      <tunable>net.inet.tcp.log_debug</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Set ICMP Limits</descr>
+      <tunable>net.inet.icmp.icmplim</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>TCP Offload Engine</descr>
+      <tunable>net.inet.tcp.tso</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>UDP Checksums</descr>
+      <tunable>net.inet.udp.checksum</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Maximum socket buffer size</descr>
+      <tunable>kern.ipc.maxsockbuf</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Page Table Isolation (Meltdown mitigation, requires reboot.)</descr>
+      <tunable>vm.pmap.pti</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Disable Indirect Branch Restricted Speculation (Spectre V2 mitigation)</descr>
+      <tunable>hw.ibrs_disable</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Hide processes running as other groups</descr>
+      <tunable>security.bsd.see_other_gids</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Hide processes running as other users</descr>
+      <tunable>security.bsd.see_other_uids</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Enable/disable sending of ICMP redirects in response to IP packets for which a better,
+        and for the sender directly reachable, route and next hop is known.
+      </descr>
+      <tunable>net.inet.ip.redirect</tunable>
+      <value>default</value>
+    </item>
+    <item>
+      <descr>Maximum outgoing UDP datagram size</descr>
+      <tunable>net.local.dgram.maxdgram</tunable>
+      <value>default</value>
+    </item>
+  </sysctl>
+  <system>
+    <optimization>normal</optimization>
+    <hostname>OPNsense</hostname>
+    <domain>lan</domain>
+    <dnsallowoverride>1</dnsallowoverride>
+    <group>
+      <name>admins</name>
+      <description>System Administrators</description>
+      <scope>system</scope>
+      <gid>1999</gid>
+      <member>0</member>
+      <priv>page-all</priv>
+    </group>
+    <user>
+      <name>root</name>
+      <descr>System Administrator</descr>
+      <scope>system</scope>
+      <groupname>admins</groupname>
+      <password>$2y$10$YRVoF4SgskIsrXOvOQjGieB9XqHPRra9R7d80B3BZdbY/j21TwBfS</password>
+      <uid>0</uid>
+    </user>
+    <nextuid>2000</nextuid>
+    <nextgid>2000</nextgid>
+    <timezone>Europe/Helsinki</timezone>
+    <timeservers>0.opnsense.pool.ntp.org 1.opnsense.pool.ntp.org 2.opnsense.pool.ntp.org 3.opnsense.pool.ntp.org</timeservers>
+    <webgui>
+      <protocol>https</protocol>
+      <ssl-certref>6782b5976cee0</ssl-certref>
+      <port/>
+      <ssl-ciphers/>
+      <interfaces>lan</interfaces>
+      <compression/>
+    </webgui>
+    <disablenatreflection>yes</disablenatreflection>
+    <usevirtualterminal>1</usevirtualterminal>
+    <disableconsolemenu>1</disableconsolemenu>
+    <disablevlanhwfilter>1</disablevlanhwfilter>
+    <disablechecksumoffloading>1</disablechecksumoffloading>
+    <disablesegmentationoffloading>1</disablesegmentationoffloading>
+    <disablelargereceiveoffloading>1</disablelargereceiveoffloading>
+    <ipv6allow>1</ipv6allow>
+    <powerd_ac_mode>hadp</powerd_ac_mode>
+    <powerd_battery_mode>hadp</powerd_battery_mode>
+    <powerd_normal_mode>hadp</powerd_normal_mode>
+    <bogons>
+      <interval>monthly</interval>
+    </bogons>
+    <pf_share_forward>1</pf_share_forward>
+    <lb_use_sticky>1</lb_use_sticky>
+    <ssh>
+      <group>admins</group>
+      <noauto>1</noauto>
+      <interfaces/>
+      <kex/>
+      <ciphers/>
+      <macs/>
+      <keys/>
+      <keysig/>
+      <rekeylimit/>
+    </ssh>
+    <rrdbackup>-1</rrdbackup>
+    <netflowbackup>-1</netflowbackup>
+    <firmware version="1.0.1">
+      <mirror/>
+      <flavour/>
+      <plugins>os-realtek-re</plugins>
+      <type/>
+      <subscription/>
+      <reboot/>
+    </firmware>
+    <language>en_US</language>
+    <dnsserver>1.1.1.1</dnsserver>
+    <dnsserver>1.0.0.1</dnsserver>
+    <dnsallowoverride_exclude/>
+    <dns1gw>none</dns1gw>
+    <dns2gw>none</dns2gw>
+    <dns3gw>none</dns3gw>
+    <dns4gw>none</dns4gw>
+    <dns5gw>none</dns5gw>
+    <dns6gw>none</dns6gw>
+    <dns7gw>none</dns7gw>
+    <dns8gw>none</dns8gw>
+    <serialspeed>115200</serialspeed>
+    <primaryconsole>video</primaryconsole>
+  </system>
+  <interfaces>
+    <wan>
+      <if>re1</if>
+      <descr>WAN</descr>
+      <enable>1</enable>
+      <spoofmac/>
+      <blockpriv>1</blockpriv>
+      <blockbogons>1</blockbogons>
+      <ipaddr>dhcp</ipaddr>
+      <dhcphostname/>
+      <alias-address/>
+      <alias-subnet>32</alias-subnet>
+      <dhcprejectfrom/>
+      <adv_dhcp_pt_timeout/>
+      <adv_dhcp_pt_retry/>
+      <adv_dhcp_pt_select_timeout/>
+      <adv_dhcp_pt_reboot/>
+      <adv_dhcp_pt_backoff_cutoff/>
+      <adv_dhcp_pt_initial_interval/>
+      <adv_dhcp_pt_values>SavedCfg</adv_dhcp_pt_values>
+      <adv_dhcp_send_options/>
+      <adv_dhcp_request_options/>
+      <adv_dhcp_required_options/>
+      <adv_dhcp_option_modifiers/>
+      <adv_dhcp_config_advanced/>
+      <adv_dhcp_config_file_override/>
+      <adv_dhcp_config_file_override_path/>
+      <ipaddrv6>dhcp6</ipaddrv6>
+      <dhcp6-ia-pd-len>0</dhcp6-ia-pd-len>
+      <adv_dhcp6_interface_statement_send_options/>
+      <adv_dhcp6_interface_statement_request_options/>
+      <adv_dhcp6_interface_statement_information_only_enable/>
+      <adv_dhcp6_interface_statement_script/>
+      <adv_dhcp6_id_assoc_statement_address_enable/>
+      <adv_dhcp6_id_assoc_statement_address/>
+      <adv_dhcp6_id_assoc_statement_address_id/>
+      <adv_dhcp6_id_assoc_statement_address_pltime/>
+      <adv_dhcp6_id_assoc_statement_address_vltime/>
+      <adv_dhcp6_id_assoc_statement_prefix_enable/>
+      <adv_dhcp6_id_assoc_statement_prefix/>
+      <adv_dhcp6_id_assoc_statement_prefix_id/>
+      <adv_dhcp6_id_assoc_statement_prefix_pltime/>
+      <adv_dhcp6_id_assoc_statement_prefix_vltime/>
+      <adv_dhcp6_prefix_interface_statement_sla_len/>
+      <adv_dhcp6_authentication_statement_authname/>
+      <adv_dhcp6_authentication_statement_protocol/>
+      <adv_dhcp6_authentication_statement_algorithm/>
+      <adv_dhcp6_authentication_statement_rdm/>
+      <adv_dhcp6_key_info_statement_keyname/>
+      <adv_dhcp6_key_info_statement_realm/>
+      <adv_dhcp6_key_info_statement_keyid/>
+      <adv_dhcp6_key_info_statement_secret/>
+      <adv_dhcp6_key_info_statement_expire/>
+      <adv_dhcp6_config_advanced/>
+      <adv_dhcp6_config_file_override/>
+      <adv_dhcp6_config_file_override_path/>
+    </wan>
+    <lan>
+      <enable>1</enable>
+      <if>re0</if>
+      <ipaddr>192.168.1.1</ipaddr>
+      <subnet>24</subnet>
+      <ipaddrv6>track6</ipaddrv6>
+      <subnetv6>64</subnetv6>
+      <media/>
+      <mediaopt/>
+      <track6-interface>wan</track6-interface>
+      <track6-prefix-id>0</track6-prefix-id>
+      <descr>LAN</descr>
+    </lan>
+    <lo0>
+      <internal_dynamic>1</internal_dynamic>
+      <descr>Loopback</descr>
+      <enable>1</enable>
+      <if>lo0</if>
+      <ipaddr>127.0.0.1</ipaddr>
+      <ipaddrv6>::1</ipaddrv6>
+      <subnet>8</subnet>
+      <subnetv6>128</subnetv6>
+      <type>none</type>
+      <virtual>1</virtual>
+    </lo0>
+    <opt1>
+      <if>vlan01</if>
+      <descr>OPT1</descr>
+      <enable>1</enable>
+      <spoofmac/>
+      <ipaddr>10.0.0.1</ipaddr>
+      <subnet>24</subnet>
+    </opt1>
+  </interfaces>
+  <dhcpd>
+    <lan>
+      <enable/>
+      <range>
+        <from>192.168.1.10</from>
+        <to>192.168.1.245</to>
+      </range>
+      <staticmap>
+        <mac>54:80:28:ec:39:60</mac>
+        <ipaddr>192.168.1.100</ipaddr>
+        <hostname>kytkin</hostname>
+        <winsserver/>
+        <dnsserver/>
+        <ntpserver/>
+      </staticmap>
+    </lan>
+    <opt1>
+      <enable>1</enable>
+      <ddnsdomainalgorithm>hmac-md5</ddnsdomainalgorithm>
+      <numberoptions>
+        <item/>
+      </numberoptions>
+      <range>
+        <from>10.0.0.100</from>
+        <to>10.0.0.199</to>
+      </range>
+      <winsserver/>
+      <dnsserver/>
+      <ntpserver/>
+    </opt1>
+  </dhcpd>
+  <snmpd>
+    <syslocation/>
+    <syscontact/>
+    <rocommunity>public</rocommunity>
+  </snmpd>
+  <nat>
+    <outbound>
+      <mode>automatic</mode>
+    </outbound>
+  </nat>
+  <filter>
+    <rule uuid="18ed31d1-5eb9-44d2-99b1-925e02170341">
+      <type>pass</type>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Default allow LAN to any rule</descr>
+      <interface>lan</interface>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any/>
+      </destination>
+    </rule>
+    <rule uuid="4e38f4ba-7a2b-4b21-b8f4-1b76c42c7c6d">
+      <type>pass</type>
+      <ipprotocol>inet6</ipprotocol>
+      <descr>Default allow LAN IPv6 to any rule</descr>
+      <interface>lan</interface>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any/>
+      </destination>
+    </rule>
+    <rule uuid="42db3107-5ee1-4504-bc45-fbfa3ec1ec8a">
+      <type>reject</type>
+      <interface>opt1</interface>
+      <ipprotocol>inet</ipprotocol>
+      <statetype>keep state</statetype>
+      <direction>in</direction>
+      <quick>1</quick>
+      <source>
+        <network>opt1</network>
+      </source>
+      <destination>
+        <network>lan</network>
+      </destination>
+      <updated>
+        <username>root@192.168.1.91</username>
+        <time>1736683170.9714</time>
+        <description>/firewall_rules_edit.php made changes</description>
+      </updated>
+      <created>
+        <username>root@192.168.1.91</username>
+        <time>1736683170.9714</time>
+        <description>/firewall_rules_edit.php made changes</description>
+      </created>
+    </rule>
+    <rule uuid="7c92021a-802c-4a69-bba8-af1f14c83c64">
+      <type>pass</type>
+      <interface>opt1</interface>
+      <ipprotocol>inet</ipprotocol>
+      <statetype>keep state</statetype>
+      <direction>in</direction>
+      <quick>1</quick>
+      <source>
+        <network>opt1</network>
+      </source>
+      <destination>
+        <any>1</any>
+      </destination>
+      <updated>
+        <username>root@192.168.1.91</username>
+        <time>1736683134.5991</time>
+        <description>/firewall_rules_edit.php made changes</description>
+      </updated>
+      <created>
+        <username>root@192.168.1.91</username>
+        <time>1736682616.9219</time>
+        <description>/firewall_rules_edit.php made changes</description>
+      </created>
+    </rule>
+  </filter>
+  <rrd>
+    <enable/>
+  </rrd>
+  <ntpd>
+    <prefer>0.opnsense.pool.ntp.org</prefer>
+  </ntpd>
+  <revision>
+    <username>root@10.0.0.100</username>
+    <time>1736683277.6237</time>
+    <description>/system_advanced_admin.php made changes</description>
+  </revision>
+  <OPNsense>
+    <OpenVPNExport version="0.0.1">
+      <servers/>
+    </OpenVPNExport>
+    <OpenVPN version="1.0.1">
+      <Overwrites/>
+      <Instances/>
+      <StaticKeys/>
+    </OpenVPN>
+    <wireguard>
+      <server version="1.0.0">
+        <servers/>
+      </server>
+      <client version="1.0.0">
+        <clients/>
+      </client>
+      <general version="0.0.1">
+        <enabled>0</enabled>
+      </general>
+    </wireguard>
+    <captiveportal version="1.0.2">
+      <zones/>
+      <templates/>
+    </captiveportal>
+    <monit version="1.0.13">
+      <general>
+        <enabled>0</enabled>
+        <interval>120</interval>
+        <startdelay>120</startdelay>
+        <mailserver>127.0.0.1</mailserver>
+        <port>25</port>
+        <username/>
+        <password/>
+        <ssl>0</ssl>
+        <sslversion>auto</sslversion>
+        <sslverify>1</sslverify>
+        <logfile/>
+        <statefile/>
+        <eventqueuePath/>
+        <eventqueueSlots/>
+        <httpdEnabled>0</httpdEnabled>
+        <httpdUsername>root</httpdUsername>
+        <httpdPassword/>
+        <httpdPort>2812</httpdPort>
+        <httpdAllow/>
+        <mmonitUrl/>
+        <mmonitTimeout>5</mmonitTimeout>
+        <mmonitRegisterCredentials>1</mmonitRegisterCredentials>
+      </general>
+      <alert uuid="1b802d95-63ff-4589-bcc4-2de4671e7e75">
+        <enabled>0</enabled>
+        <recipient>root@localhost.local</recipient>
+        <noton>0</noton>
+        <events/>
+        <format/>
+        <reminder/>
+        <description/>
+      </alert>
+      <service uuid="07e9af27-36af-4c5c-a7eb-efaded45bb8a">
+        <enabled>1</enabled>
+        <name>$HOST</name>
+        <description/>
+        <type>system</type>
+        <pidfile/>
+        <match/>
+        <path/>
+        <timeout>300</timeout>
+        <starttimeout>30</starttimeout>
+        <address/>
+        <interface/>
+        <start/>
+        <stop/>
+        <tests>48010f3d-1361-4bd4-ad82-b0ba87b8846e,972bde76-9adf-4ee6-8403-2acc4b29733d,f3b8cfa7-82c0-41cc-9561-a7a41ef27815,38d7d62c-9666-4512-9ee2-3721236cc840</tests>
+        <depends/>
+        <polltime/>
+      </service>
+      <service uuid="e858bff8-b2b2-4bbd-83c4-f188848d2716">
+        <enabled>1</enabled>
+        <name>RootFs</name>
+        <description/>
+        <type>filesystem</type>
+        <pidfile/>
+        <match/>
+        <path>/</path>
+        <timeout>300</timeout>
+        <starttimeout>30</starttimeout>
+        <address/>
+        <interface/>
+        <start/>
+        <stop/>
+        <tests>1e2803a5-2c70-49c1-b5c7-f36a3519bc10</tests>
+        <depends/>
+        <polltime/>
+      </service>
+      <service uuid="0078be79-2337-4d66-ae4d-a8c5a5063f4a">
+        <enabled>0</enabled>
+        <name>carp_status_change</name>
+        <description/>
+        <type>custom</type>
+        <pidfile/>
+        <match/>
+        <path>/usr/local/opnsense/scripts/OPNsense/Monit/carp_status</path>
+        <timeout>300</timeout>
+        <starttimeout>30</starttimeout>
+        <address/>
+        <interface/>
+        <start/>
+        <stop/>
+        <tests>17876f2e-0140-458f-998b-ff3043e7d3a9</tests>
+        <depends/>
+        <polltime/>
+      </service>
+      <service uuid="6ec26c55-042b-4133-a3f7-edf64cb0ba22">
+        <enabled>0</enabled>
+        <name>gateway_alert</name>
+        <description/>
+        <type>custom</type>
+        <pidfile/>
+        <match/>
+        <path>/usr/local/opnsense/scripts/OPNsense/Monit/gateway_alert</path>
+        <timeout>300</timeout>
+        <starttimeout>30</starttimeout>
+        <address/>
+        <interface/>
+        <start/>
+        <stop/>
+        <tests>473764b3-6b3b-4b77-8f0e-261eeac24c3c</tests>
+        <depends/>
+        <polltime/>
+      </service>
+      <test uuid="733d6d61-d947-4f7f-bd73-8ec8696d0789">
+        <name>Ping</name>
+        <type>NetworkPing</type>
+        <condition>failed ping</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="3d6a614e-f006-4884-b6f2-a27800467c83">
+        <name>NetworkLink</name>
+        <type>NetworkInterface</type>
+        <condition>failed link</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="94f55752-9469-44e4-b039-c03a7b3666be">
+        <name>NetworkSaturation</name>
+        <type>NetworkInterface</type>
+        <condition>saturation is greater than 75%</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="48010f3d-1361-4bd4-ad82-b0ba87b8846e">
+        <name>MemoryUsage</name>
+        <type>SystemResource</type>
+        <condition>memory usage is greater than 75%</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="972bde76-9adf-4ee6-8403-2acc4b29733d">
+        <name>CPUUsage</name>
+        <type>SystemResource</type>
+        <condition>cpu usage is greater than 75%</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="f3b8cfa7-82c0-41cc-9561-a7a41ef27815">
+        <name>LoadAvg1</name>
+        <type>SystemResource</type>
+        <condition>loadavg (1min) is greater than 8</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="38d7d62c-9666-4512-9ee2-3721236cc840">
+        <name>LoadAvg5</name>
+        <type>SystemResource</type>
+        <condition>loadavg (5min) is greater than 6</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="e5f0d8a0-7966-47ae-a3a7-461d6d55a710">
+        <name>LoadAvg15</name>
+        <type>SystemResource</type>
+        <condition>loadavg (15min) is greater than 4</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="1e2803a5-2c70-49c1-b5c7-f36a3519bc10">
+        <name>SpaceUsage</name>
+        <type>SpaceUsage</type>
+        <condition>space usage is greater than 75%</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="17876f2e-0140-458f-998b-ff3043e7d3a9">
+        <name>ChangedStatus</name>
+        <type>ProgramStatus</type>
+        <condition>changed status</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+      <test uuid="473764b3-6b3b-4b77-8f0e-261eeac24c3c">
+        <name>NonZeroStatus</name>
+        <type>ProgramStatus</type>
+        <condition>status != 0</condition>
+        <action>alert</action>
+        <path/>
+      </test>
+    </monit>
+    <trust>
+      <general version="1.0.1">
+        <store_intermediate_certs>0</store_intermediate_certs>
+        <install_crls>0</install_crls>
+        <fetch_crls>0</fetch_crls>
+        <enable_legacy_sect>1</enable_legacy_sect>
+        <enable_config_constraints>0</enable_config_constraints>
+        <CipherString/>
+        <Ciphersuites/>
+        <SignatureAlgorithms/>
+        <groups/>
+        <MinProtocol/>
+        <MinProtocol_DTLS/>
+      </general>
+    </trust>
+    <Firewall>
+      <Filter version="1.0.4">
+        <rules/>
+        <snatrules/>
+        <npt/>
+        <onetoone/>
+      </Filter>
+      <Alias version="1.0.1">
+        <geoip>
+          <url/>
+        </geoip>
+        <aliases/>
+      </Alias>
+      <Category version="1.0.0">
+        <categories/>
+      </Category>
+      <Lvtemplate version="0.0.1">
+        <templates/>
+      </Lvtemplate>
+    </Firewall>
+    <Syslog version="1.0.2">
+      <general>
+        <enabled>1</enabled>
+        <loglocal>1</loglocal>
+        <maxpreserve>31</maxpreserve>
+        <maxfilesize/>
+      </general>
+      <destinations/>
+    </Syslog>
+    <cron version="1.0.4">
+      <jobs/>
+    </cron>
+    <IPsec version="1.0.3">
+      <general>
+        <enabled/>
+        <preferred_oldsa>0</preferred_oldsa>
+        <disablevpnrules>0</disablevpnrules>
+        <passthrough_networks/>
+      </general>
+      <charon>
+        <max_ikev1_exchanges/>
+        <threads>16</threads>
+        <ikesa_table_size>32</ikesa_table_size>
+        <ikesa_table_segments>4</ikesa_table_segments>
+        <init_limit_half_open>1000</init_limit_half_open>
+        <ignore_acquire_ts>1</ignore_acquire_ts>
+        <make_before_break/>
+        <retransmit_tries/>
+        <retransmit_timeout/>
+        <retransmit_base/>
+        <retransmit_jitter/>
+        <retransmit_limit/>
+        <syslog>
+          <daemon>
+            <ike_name>1</ike_name>
+            <log_level>0</log_level>
+            <app>1</app>
+            <asn>1</asn>
+            <cfg>1</cfg>
+            <chd>1</chd>
+            <dmn>1</dmn>
+            <enc>1</enc>
+            <esp>1</esp>
+            <ike>1</ike>
+            <imc>1</imc>
+            <imv>1</imv>
+            <job>1</job>
+            <knl>1</knl>
+            <lib>1</lib>
+            <mgr>1</mgr>
+            <net>1</net>
+            <pts>1</pts>
+            <tls>1</tls>
+            <tnc>1</tnc>
+          </daemon>
+        </syslog>
+      </charon>
+      <keyPairs/>
+      <preSharedKeys/>
+    </IPsec>
+    <Swanctl version="1.0.0">
+      <Connections/>
+      <locals/>
+      <remotes/>
+      <children/>
+      <Pools/>
+      <VTIs/>
+      <SPDs/>
+    </Swanctl>
+    <TrafficShaper version="1.0.3">
+      <pipes>
+        <pipe uuid="ab0647c0-21cc-44e8-a2e2-c2e97334fada">
+          <number>10000</number>
+          <enabled>1</enabled>
+          <bandwidth>100</bandwidth>
+          <bandwidthMetric>Mbit</bandwidthMetric>
+          <queue/>
+          <mask>dst-ip</mask>
+          <buckets/>
+          <scheduler/>
+          <codel_enable>0</codel_enable>
+          <codel_target/>
+          <codel_interval/>
+          <codel_ecn_enable>0</codel_ecn_enable>
+          <pie_enable>0</pie_enable>
+          <fqcodel_quantum/>
+          <fqcodel_limit/>
+          <fqcodel_flows/>
+          <origin>TrafficShaper</origin>
+          <delay/>
+          <description>limit</description>
+        </pipe>
+      </pipes>
+      <queues>
+        <queue uuid="43a17369-c61d-4642-b316-260234daa08f">
+          <number>10000</number>
+          <enabled>1</enabled>
+          <pipe>ab0647c0-21cc-44e8-a2e2-c2e97334fada</pipe>
+          <weight>100</weight>
+          <mask>none</mask>
+          <buckets/>
+          <codel_enable>0</codel_enable>
+          <codel_target/>
+          <codel_interval/>
+          <codel_ecn_enable>0</codel_ecn_enable>
+          <pie_enable>0</pie_enable>
+          <description>limit</description>
+          <origin>TrafficShaper</origin>
+        </queue>
+      </queues>
+      <rules>
+        <rule uuid="6b5d6acc-939d-4304-afe1-ee72684c8083">
+          <enabled>1</enabled>
+          <sequence>1</sequence>
+          <interface>opt1</interface>
+          <interface2/>
+          <proto>ip</proto>
+          <iplen/>
+          <source>any</source>
+          <source_not>0</source_not>
+          <src_port>any</src_port>
+          <destination>any</destination>
+          <destination_not>0</destination_not>
+          <dst_port>any</dst_port>
+          <dscp/>
+          <direction/>
+          <target>ab0647c0-21cc-44e8-a2e2-c2e97334fada</target>
+          <description>limit</description>
+          <origin>TrafficShaper</origin>
+        </rule>
+      </rules>
+    </TrafficShaper>
+    <unboundplus version="1.0.11">
+      <general>
+        <enabled>1</enabled>
+        <port>53</port>
+        <stats/>
+        <active_interface/>
+        <dnssec/>
+        <dns64/>
+        <dns64prefix/>
+        <noarecords/>
+        <regdhcp/>
+        <regdhcpdomain/>
+        <regdhcpstatic/>
+        <noreglladdr6/>
+        <noregrecords/>
+        <txtsupport/>
+        <cacheflush/>
+        <local_zone_type>transparent</local_zone_type>
+        <outgoing_interface/>
+        <enable_wpad/>
+      </general>
+      <advanced>
+        <hideidentity/>
+        <hideversion/>
+        <prefetch/>
+        <prefetchkey/>
+        <dnssecstripped/>
+        <aggressivensec>1</aggressivensec>
+        <serveexpired/>
+        <serveexpiredreplyttl/>
+        <serveexpiredttl/>
+        <serveexpiredttlreset/>
+        <serveexpiredclienttimeout/>
+        <qnameminstrict/>
+        <extendedstatistics/>
+        <logqueries/>
+        <logreplies/>
+        <logtagqueryreply/>
+        <logservfail/>
+        <loglocalactions/>
+        <logverbosity>1</logverbosity>
+        <valloglevel>0</valloglevel>
+        <privatedomain/>
+        <privateaddress>0.0.0.0/8,10.0.0.0/8,100.64.0.0/10,169.254.0.0/16,172.16.0.0/12,192.0.2.0/24,192.168.0.0/16,198.18.0.0/15,198.51.100.0/24,203.0.113.0/24,233.252.0.0/24,::1/128,2001:db8::/32,fc00::/8,fd00::/8,fe80::/10</privateaddress>
+        <insecuredomain/>
+        <msgcachesize/>
+        <rrsetcachesize/>
+        <outgoingnumtcp/>
+        <incomingnumtcp/>
+        <numqueriesperthread/>
+        <outgoingrange/>
+        <jostletimeout/>
+        <discardtimeout/>
+        <cachemaxttl/>
+        <cachemaxnegativettl/>
+        <cacheminttl/>
+        <infrahostttl/>
+        <infrakeepprobing/>
+        <infracachenumhosts/>
+        <unwantedreplythreshold/>
+      </advanced>
+      <acls>
+        <default_action>allow</default_action>
+      </acls>
+      <dnsbl>
+        <enabled>0</enabled>
+        <safesearch/>
+        <type/>
+        <lists/>
+        <whitelists/>
+        <blocklists/>
+        <wildcards/>
+        <address/>
+        <nxdomain/>
+      </dnsbl>
+      <forwarding>
+        <enabled/>
+      </forwarding>
+      <dots/>
+      <hosts>
+        <host uuid="6149d265-922e-4e77-bf8d-da35c3e8c9b8">
+          <enabled>1</enabled>
+          <hostname>kytkin</hostname>
+          <domain>lan</domain>
+          <rr>A</rr>
+          <mxprio/>
+          <mx/>
+          <server>192.168.1.100</server>
+          <description/>
+        </host>
+        <host uuid="29536bbd-9611-4d44-987d-3383c6c5618d">
+          <enabled>1</enabled>
+          <hostname>opnsense</hostname>
+          <domain>lan</domain>
+          <rr>A</rr>
+          <mxprio/>
+          <mx/>
+          <server>192.168.1.1</server>
+          <description/>
+        </host>
+      </hosts>
+      <aliases/>
+    </unboundplus>
+    <IDS version="1.1.0">
+      <rules/>
+      <policies/>
+      <userDefinedRules/>
+      <files/>
+      <fileTags/>
+      <general>
+        <enabled>0</enabled>
+        <ips>0</ips>
+        <promisc>0</promisc>
+        <interfaces>wan</interfaces>
+        <homenet>192.168.0.0/16,10.0.0.0/8,172.16.0.0/12</homenet>
+        <defaultPacketSize/>
+        <UpdateCron/>
+        <AlertLogrotate>W0D23</AlertLogrotate>
+        <AlertSaveLogs>4</AlertSaveLogs>
+        <MPMAlgo/>
+        <detect>
+          <Profile/>
+          <toclient_groups/>
+          <toserver_groups/>
+        </detect>
+        <syslog>0</syslog>
+        <syslog_eve>0</syslog_eve>
+        <LogPayload>0</LogPayload>
+        <verbosity/>
+        <eveLog>
+          <http>
+            <enable>0</enable>
+            <extended>0</extended>
+            <dumpAllHeaders/>
+          </http>
+          <tls>
+            <enable>0</enable>
+            <extended>0</extended>
+            <sessionResumption>0</sessionResumption>
+            <custom/>
+          </tls>
+        </eveLog>
+      </general>
+    </IDS>
+    <DHCRelay version="1.0.1"/>
+    <Interfaces>
+      <neighbors version="1.0.0"/>
+      <vxlans version="1.0.2"/>
+      <loopbacks version="1.0.0"/>
+    </Interfaces>
+    <Kea>
+      <dhcp4 version="1.0.2">
+        <general>
+          <enabled>0</enabled>
+          <interfaces/>
+          <valid_lifetime>4000</valid_lifetime>
+          <fwrules>1</fwrules>
+          <dhcp_socket_type>raw</dhcp_socket_type>
+        </general>
+        <ha>
+          <enabled>0</enabled>
+          <this_server_name/>
+          <max_unacked_clients>2</max_unacked_clients>
+        </ha>
+        <subnets/>
+        <reservations/>
+        <ha_peers/>
+      </dhcp4>
+      <ctrl_agent version="0.0.1">
+        <general>
+          <enabled>0</enabled>
+          <http_host>127.0.0.1</http_host>
+          <http_port>8000</http_port>
+        </general>
+      </ctrl_agent>
+    </Kea>
+    <Gateways version="1.0.0">
+      <gateway_item uuid="06221e65-9b12-40cb-9ccd-c9aaab37c34d">
+        <disabled>0</disabled>
+        <name>WAN_GW</name>
+        <descr>WAN Gateway</descr>
+        <interface>wan</interface>
+        <ipprotocol>inet</ipprotocol>
+        <gateway/>
+        <defaultgw>1</defaultgw>
+        <fargw/>
+        <monitor_disable>1</monitor_disable>
+        <monitor_noroute/>
+        <monitor/>
+        <force_down/>
+        <priority>255</priority>
+        <weight>1</weight>
+        <latencylow/>
+        <latencyhigh/>
+        <losslow/>
+        <losshigh/>
+        <interval/>
+        <time_period/>
+        <loss_interval/>
+        <data_length/>
+      </gateway_item>
+    </Gateways>
+    <Netflow version="1.0.1">
+      <capture>
+        <interfaces/>
+        <egress_only/>
+        <version>v9</version>
+        <targets/>
+      </capture>
+      <collect>
+        <enable>0</enable>
+      </collect>
+      <activeTimeout>1800</activeTimeout>
+      <inactiveTimeout>15</inactiveTimeout>
+    </Netflow>
+  </OPNsense>
+  <openvpn/>
+  <hasync version="1.0.1">
+    <disablepreempt>0</disablepreempt>
+    <disconnectppps>0</disconnectppps>
+    <pfsyncinterface/>
+    <pfsyncpeerip/>
+    <pfsyncversion>1400</pfsyncversion>
+    <synchronizetoip/>
+    <username/>
+    <password/>
+    <syncitems/>
+  </hasync>
+  <ifgroups version="1.0.0"/>
+  <gifs version="1.0.0">
+    <gif/>
+  </gifs>
+  <gres version="1.0.0">
+    <gre/>
+  </gres>
+  <laggs version="1.0.0">
+    <lagg/>
+  </laggs>
+  <virtualip version="1.0.0">
+    <vip/>
+  </virtualip>
+  <vlans version="1.0.0">
+    <vlan uuid="ead1d50a-b1d5-4613-af77-e561d5bb1e92">
+      <if>re0</if>
+      <tag>2</tag>
+      <pcp>0</pcp>
+      <proto/>
+      <descr>koneet</descr>
+      <vlanif>vlan01</vlanif>
+    </vlan>
+  </vlans>
+  <staticroutes version="1.0.0">
+    <route/>
+  </staticroutes>
+  <bridges>
+    <bridged/>
+  </bridges>
+  <ppps>
+    <ppp/>
+  </ppps>
+  <wireless>
+    <clone/>
+  </wireless>
+  <ca/>
+  <dhcpdv6/>
+  <cert uuid="84a61eb3-d461-4425-848d-cfd814bc7d93">
+    <refid>6782b5976cee0</refid>
+    <descr>Web GUI TLS certificate</descr>
+    <caref/>
+    <crt>LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUhIakNDQlFhZ0F3SUJBZ0lVQ2E2TGtjdUJNV1hwQklSQk9pcGJGM2g3ak5nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZa3hIVEFiQmdOVkJBTU1GRTlRVG5ObGJuTmxMbXh2WTJGc1pHOXRZV2x1TVFzd0NRWURWUVFHRXdKTwpUREVWTUJNR0ExVUVDQXdNV25WcFpDMUliMnhzWVc1a01SVXdFd1lEVlFRSERBeE5hV1JrWld4b1lYSnVhWE14CkxUQXJCZ05WQkFvTUpFOVFUbk5sYm5ObElITmxiR1l0YzJsbmJtVmtJSGRsWWlCalpYSjBhV1pwWTJGMFpUQWUKRncweU5UQXhNVEV4T0RFM01ETmFGdzB5TmpBeU1USXhPREUzTUROYU1JR0pNUjB3R3dZRFZRUUREQlJQVUU1egpaVzV6WlM1c2IyTmhiR1J2YldGcGJqRUxNQWtHQTFVRUJoTUNUa3d4RlRBVEJnTlZCQWdNREZwMWFXUXRTRzlzCmJHRnVaREVWTUJNR0ExVUVCd3dNVFdsa1pHVnNhR0Z5Ym1sek1TMHdLd1lEVlFRS0RDUlBVRTV6Wlc1elpTQnoKWld4bUxYTnBaMjVsWkNCM1pXSWdZMlZ5ZEdsbWFXTmhkR1V3Z2dJaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQwpEd0F3Z2dJS0FvSUNBUUMxWHhQaDNncG5Cd21iRGlLN05BeGY1YVZNYUhjZ1ZSUmpSczN5N1RSYTVMREsyWHh2CnJHQ1U4Sk1pSmtCV0tEZUozTTI0NXJSb2doZmhCYURpTktEQU5DVkNnalRUWC9xUFdBZHR0TUJaTWVvWXdwMGEKT0hYait1ZHZ0UjU2RjBnMkFheE4ySUMxbWJHN1lId0tnczl4Tkx5Tmk4bDZodFUzL0xyNmhEL3J1VVQ5UUNzZApubkhkT1lESExSOUloNC9PYVh5dE9CNmVyQVdDWkRJaDJ4c2NkcllFTWtKMWl4RitiZWtYa1o3Ni9ZSFA2cFRICjNwb3VJemx3aFJLSEQ4MVpZdHRPL2psb3d6a2xNd3d0Z2JoUXAreW9OeTY3U2dRWWRiZ2Zsd1RBRWM4SXM2S1UKREVXSnE2VkpIWE05S2pST095YkdoMzl4NlBNaS8wVE12RldGK1d3aHBrU25tcjdnSzBOQTBkQjZiZUVrTCtzdQprV01FaGV6Y2RHSDBJeEpybTl5L0tDcEtTUll1eHF6N1A2RXEyMlk1eitMOHFSaE1rcTVVeVFRWDZvV0x6L3p3Ckc0djZUNFpBREVkWkwxd2IzYW03OFUxREJzbFVoQnp6Vkx4azRwdjRYU21PbDI5UFNaZDBnQUhWcXRrN00ybDMKeVRDbWVOc3hzQTZWemlsR2pHVGo3dFFFaFhzRGFobUlKRFZMREZ5cGVtWTdwZFVmWFA5VW1lT0J5MGQxNVRQdwpkL3k0aS9BUmtPY1JENmFBaHlOU3dnY0plaXdRc0JSM0lHNHFiVGpuc203alN0Rms1ZzhwS2dkSzY2ZTFMenZMCk1qV2RPa0ltTDAwTHllVXQrdHA0bHRjRmVpcXF3Z2VmYWxUVWIzTjQ4WnE3SzJ2cEU0aVNnYndNT1FJREFRQUIKbzRJQmVqQ0NBWFl3Q1FZRFZSMFRCQUl3QURBUkJnbGdoa2dCaHZoQ0FRRUVCQU1DQmtBd05BWUpZSVpJQVliNApRZ0VOQkNjV0pVOVFUbk5sYm5ObElFZGxibVZ5WVhSbFpDQlRaWEoyWlhJZ1EyVnlkR2xtYVdOaGRHVXdIUVlEClZSME9CQllFRlBwSzRIblQ4WHdvak1IcHp6Z1NLZnp3bzl4ak1JR3pCZ05WSFNNRWdhc3dnYWloZ1kra2dZd3cKZ1lreEhUQWJCZ05WQkFNTUZFOVFUbk5sYm5ObExteHZZMkZzWkc5dFlXbHVNUXN3Q1FZRFZRUUdFd0pPVERFVgpNQk1HQTFVRUNBd01XblZwWkMxSWIyeHNZVzVrTVJVd0V3WURWUVFIREF4TmFXUmtaV3hvWVhKdWFYTXhMVEFyCkJnTlZCQW9NSkU5UVRuTmxibk5sSUhObGJHWXRjMmxuYm1Wa0lIZGxZaUJqWlhKMGFXWnBZMkYwWllJVUNhNkwKa2N1Qk1XWHBCSVJCT2lwYkYzaDdqTmd3SFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQ0FJQwpNQXNHQTFVZER3UUVBd0lGb0RBZkJnTlZIUkVFR0RBV2doUlBVRTV6Wlc1elpTNXNiMk5oYkdSdmJXRnBiakFOCkJna3Foa2lHOXcwQkFRc0ZBQU9DQWdFQWlSR1hERDZ4MkNSdmdwN2libnROOElDNEVzQ1dCdVBaUEwwWXZIUDYKdVFSQjFCQnpYdVZKSkZMQThMVExTL2hBVDhDdEJuUzhGZU9seFJZaW9kOUF1NDNFV0V1Y21OYU9sUVowZlFLTgpOZ2VSYkJsTitUQm82UDhnWVo4SDB5UkU0QzJaTmMyZkxLMGRJNXlRYk1YbTJWRW5lQi83VTM0TVZTZFRmaVNhCmJ1ZTdqYXZlR1diSSsvZFZGN1BPT2owT0lLbmoxMnZQdkk2STFjWW5NUmdMR1FvWjJRSmVsMzdtV0k0NFNQbXkKYWFxbFJMZ25oYlhKbjIzVTV1c3RjbG1rTGRVR2NlN2d0TGVJU3pTeS82eWxzS0IwWUUrQzFPWVFaVEV6YWFGYgpTYW9BVWJOZ0FmYkJxVlZqYTNpd1JueUlROFIrTTdmZzlydmt2MTlpa0htS2xjSUhkMEx1TW9nWC9XSW05UnNrClpZVU9iVHNRMkYvYUJjdHhxZTlFMHNJMGhQeXZXWHc3RW9Pa3h5QUt0QWx0dGdFU0prNzhlNUZTWW1FbVNhNUsKZ1orbFIvbVMyci9FeHBsUUdrd1BDU2IxbCtsQ2NuRnNqcmFYSjBmN2dxbjNJNUVjZHQzZlh2NmFPM3lueGpMMwpNa0ZuT2dmdEZsS1BqUnpiMU55T3pSdGxQWGVuOExzZ1lPS0VPbDNtL1hjZG90aFZmMzBRZWpPVkhtNEg5Z1V1CjZkTEgzNXdKVzVwOWZPTFR6SElqS1NaM1o0ZmwzbWI2RUllenQwS2p3MUNkNVppLzFPaXBvSWVoRFJjdEMrSGIKTnArVXdqNWF5RXA5bTFUdmp2bEkxc3lGYUJWd3J5RnQwbEV0VHQ2d1R2U0RJS045Y3l6dkh6NmRPdG9kRmUvTgpkSXM9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K</crt>
+    <csr/>
+    <prv>LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUpRZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQ1N3d2dna29BZ0VBQW9JQ0FRQzFYeFBoM2dwbkJ3bWIKRGlLN05BeGY1YVZNYUhjZ1ZSUmpSczN5N1RSYTVMREsyWHh2ckdDVThKTWlKa0JXS0RlSjNNMjQ1clJvZ2hmaApCYURpTktEQU5DVkNnalRUWC9xUFdBZHR0TUJaTWVvWXdwMGFPSFhqK3VkdnRSNTZGMGcyQWF4TjJJQzFtYkc3CllId0tnczl4Tkx5Tmk4bDZodFUzL0xyNmhEL3J1VVQ5UUNzZG5uSGRPWURITFI5SWg0L09hWHl0T0I2ZXJBV0MKWkRJaDJ4c2NkcllFTWtKMWl4RitiZWtYa1o3Ni9ZSFA2cFRIM3BvdUl6bHdoUktIRDgxWll0dE8vamxvd3prbApNd3d0Z2JoUXAreW9OeTY3U2dRWWRiZ2Zsd1RBRWM4SXM2S1VERVdKcTZWSkhYTTlLalJPT3liR2gzOXg2UE1pCi8wVE12RldGK1d3aHBrU25tcjdnSzBOQTBkQjZiZUVrTCtzdWtXTUVoZXpjZEdIMEl4SnJtOXkvS0NwS1NSWXUKeHF6N1A2RXEyMlk1eitMOHFSaE1rcTVVeVFRWDZvV0x6L3p3RzR2NlQ0WkFERWRaTDF3YjNhbTc4VTFEQnNsVQpoQnp6Vkx4azRwdjRYU21PbDI5UFNaZDBnQUhWcXRrN00ybDN5VENtZU5zeHNBNlZ6aWxHakdUajd0UUVoWHNECmFobUlKRFZMREZ5cGVtWTdwZFVmWFA5VW1lT0J5MGQxNVRQd2QveTRpL0FSa09jUkQ2YUFoeU5Td2djSmVpd1EKc0JSM0lHNHFiVGpuc203alN0Rms1ZzhwS2dkSzY2ZTFMenZMTWpXZE9rSW1MMDBMeWVVdCt0cDRsdGNGZWlxcQp3Z2VmYWxUVWIzTjQ4WnE3SzJ2cEU0aVNnYndNT1FJREFRQUJBb0lDQUFac2V0RkxUU0N2WEovbWI4VE9uVWpyCmpYVU5MQ1JKTHlMWEFxWUIwR2dQRDlOQ0Z3aXVMbkRkVm5DNnNjT21HQUFrMXcvSjhyRFM1QktmREQ3Y0cxSVkKdkFzYUtTY2xaVVB5RzdmcDAzZzFSRFBOVE1WOWVNWWRnRmljcmNWOWtVYXNaMzhOcXlnRGJMVS9hbXFhNHlCVwpKdjdORTlLUzk2Rk1nbU9BdWZJdU5Tc252SDh5T2U2RkYxMEw2WlE4TjVQWmVQRFBwZHltZmhRZ3NBVXlucDFkCm9sTzREZnplSGVnQVJPV3dvdFN1bERidmVZYUhYcWJzcmgrZ21aMDVWT05xRk1JUnBLbmp1WXMvbEJwV2dsY3YKbzJUNmZnZ1BJVGNCT3dka3UyYUJjRXpxdzlnczJSZW5ySC9RUmJad1gyV05ReHg3OXhVVjZaVko1NVM5YjQvegpGNnN4ZFNkTzNzUjlOY0FlMWdjMlY2STI4UnArMGl6T0xjN0ZCQkI5dVkyUzhrZkFwc1hVeWVidXYxZFBVUmNKClB0ZW5zNTdoSGFhN25pbjZKYnFkZVE4TE80a21uTVlQa2ZsZ0tSVFZScmlLeFptSE01UkhDTWtQOXcrY3dvNW0KcERZMkxnTHZlZXZXeWdINDdQWlpVUkVkMmJvZDMySGZCQVdZbGdRLy82bTAyV0lYZGZLcjFyUFlianAwc2dHTwprWEV5T25rM3RtU2w3R05jZ0lBMkpqdmRsS3oySnhaZFppbnFOQnNOSTZqZDZyU0RzZUxlTXpqN2kyWmt0cGpZCmdSTkhqTnFqRFBGbmQ1NmNQSDhHcEF0eWlGemk3eDlBTExoTVZHZUhlWmVpcmtEKzFzRmptWUU1aWZ5azRRdVkKN0g3SWwySjA2MnMxaTNaMk5YY0pBb0lCQVFEWno0U1ZTU1BxT3RWK1A3YzdCYzVnSGFkYVZkUEhqcC9wWEZyYwpQREtqalpkZ1VjaFRrUmVoa3E2MmFERnlmV2tRZytRcERHUDdHbXZIdnlYWHE2bXg2VllNSnFkMHg3aENuMmlhCkFXQTRHMklmQVhjZml0MElmeDNMWmgyTy9wUjYvL0dUVzJYNys3Z2NpUWlDSHRucG1LdW9uV1JZMU9KL0huZmEKZ2lTbmF2Tnp1c3prT3B0d0l4OWEzUlc1VVplazYvSlJRdnRxV2ErSmt0Zk5HZEFERExYZjBzdFR2cFlmMWpsTApDU0U3Wk5yK3V2QXhRdnZBb2xGa2V4YVEzOXcxL2NlZkhDOUZXMmhEQWpSdEN0cy84L2pwZzN0Mk5QM1pWa0NUCkVzaFphckRxdEEzczFWZi9WbkZUS3lTZjVNNUtYZ2taZFc1bUZ2Z2xuZ0dQUkdZTkFvSUJBUURWSy9vQ0NXc1gKcFhtVEE2WG56UnlMZVVabDczeUNMWXhMaTJJcHRnTjVjclZvSWxubGJ1S3JYYy9nMEdpRzd1TzB6WW1oUWJKagpSR3pCeXFySUlTN3lxdVVoTk9OZS9yWHROVU5ub3BrUkNVVWlCK0FBQTVBNHZIL29YUzM4cFova2NkSDljNFphCnc2VHJxL0Q5WEYwRWlib0g5TUlJeS82dDJmN1RuOTc2djJMd25wYjFJQThxZWtma3V0VXI5SWRqOHFtTzB2d04Ka2pvWk1qa3EvWDBRemxETDF6U0hDY2dtNUNlSHpLRkxZZWZUb3JMc0hXR050Tm1wYWNhYVNyRVBoR0djTzRwSgpqa1llTDZJcWI4Qm40bjBILzBxbGpyOHV4NklTS09QWnBQVEZQVEM3eW1YRlhBdnp4ZnFUWnBRWE5yMWk5b3plCjIvQ0N0dVVZN2YvZEFvSUJBRzUrQlVZdUNsZ2liSGRWSDBDRDI0T0t4NERlRlVjZ3BTS2V4VUVBRUxoRGRjMVkKNzRUbEQ5WFpNV1E3U3dwSGNHcitYVm90ZlBLL0hub0FEOVJ1c3ZFYjY1alNheFNrMUdhSHMycWMxQkRpWTA1VApVZmpnV3V5YWY2VFZNcDE5ckJrUmlaMDFPbkV2NnVBZTdBQUdZb2xMOTVqYjd6SFpIT1Zic1hWWm0vcUtHT0pXCm11WVVqUkcvMzRJYXNaQ0hRYVJhUlZ6UDIvYkJkSGtYMHYycTRJa0xnNS85c1VQVVpSZlZkczhIM0tIaXNlMlQKSzVIeDV3QjcxMHBmM3J5enMyUjRUekg1L0VqMDY5bENYeElKOWR0bGlwbjdKMEI1OVdTeGlxU1JYSzF2b0R3UQpCeGhqeWZZd0JlRW8rN1ZaUHdVZTJ3TGRQWm53Z1FXa09DcFRpbWtDZ2dFQkFMMXJyV1UvN3p4ODJ0SHJEUEkwClRhZ1Y1SnRSdWlhR3lNS2NJV2NGQ0lOVGphVHgyVVhKU1h1VENkUXYvS0hpQnM2elVSZk1vL0lYYkRpcm1TUHEKY0toTGVQMFAzUGFkaVJVMkhpWXAwcS9UdCsyc1o3dzdibDBzQ3RCMGRCZXJLTEE2LzZpaWpnRjdGY0lnOEN5QwpkVmxCOU45Nit5d0w4TXVWQ1I0TlVuc25zNGd5czlzdldLcWJLK1V3cTVtNldOQlVZWnk3R0NRTENyczI2SnV0CjBnTXNBWm1RS21uUUpGMkNvU25IaUkvT2VNeVRKMEF1UDNCSEFwN0traUtxT2ptYW5ZM1JUbWxjRml4ZWtVLzYKSzFOa2EwdSs2eHJBQkZ4U0lrN1dyTmpKL29LQmhCdHFseEpQWDRPSEtjanUvcXErQm4yNHJhYWVjMUlEcVFHRgpBclVDZ2dFQU5rWmlIa2ZjRGtabHdVVzNFZ1BtanpaR3hYRE8wa2ZmS0hTTFJtcUNJcXBOWjBVVTZ2YURBa0NBCkc2aGRaM0hLUGM5Snk4WTd2L0kzQXhPK1d0Y3VhbUk4Sm5XZzcxcUFWbFRFb1g3YXZ4enN5bEpxVGFld1RWQ0MKbVhkMUE1T2VUUEV6MUxmcUtTNERiT2lCTmpLWE5RSFJMWXFicEhxYm9UYk9xNGZBajRIVG5sOXVabGV1bDBJcgpVVEcwY1B5aHA0S1QvRmVyR09rdXkrZGs2eGpSVStZUnluOTNCWlJvb2t1T05qVkY3c0VOdDUyRy8wa2JYdUQzCjNrV3c4Y0RvT1JESjNTelRyQUpHZEJ0OVRLdWNQT040YUs3dzVKYUNmOTF5cDF6ZFJLUGYrc3JJWmcyN0FVMWoKcW1JamVsMmRJVTJwNDY0Zy9GTjV6dExnNmtEM1JnPT0KLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=</prv>
+  </cert>
+  <syslog/>
+</opnsense>


### PR DESCRIPTION
Ports 1-8 in subnet 10.0.0.0/24, VLAN tag 2 (Clients)
Ports 9-10 in subnet 192.168.1.0/24, VLAN tag 1 (Management)

Connect WAN to OPNsense box 2.5Gbe port (Upper)
Connect HP Aruba port 10 to OPNsense box Gbe port (Lower)

Access from 10.x subnet restricted to WAN only
Bandwith limited to 100 Mbit/s per client on 10.x subnet

Hostnames and static DHCP leases:


| IP Address    | Hostname     |
| ------------- | ------------ |
| 192.168.1.1   | opnsense.lan |
| 192.168.1.100 | kytkin.lan   |
