### PR TITLE
Updates to CS2 repair process, plugin versions

### DIFF
--- a/.env
+++ b/.env
@@ -27,10 +27,10 @@ TV_MAXRATE=0
 TV_PORT=27020
 
 # Latest metamod download url can be found from https://www.metamodsource.net/downloads.php?branch=dev
-METAMOD_RELEASE_URL=https://mms.alliedmods.net/mmsdrop/2.0/mmsource-2.0.0-git1382-linux.tar.gz
+METAMOD_RELEASE_URL=https://mms.alliedmods.net/mmsdrop/2.0/mmsource-2.0.0-git1383-linux.tar.gz
 
 # Latest cssharp download url can be found from https://github.com/roflmuffin/CounterStrikeSharp/releases (the one with runtime)
-CSSHARP_RELEASE_URL=https://github.com/roflmuffin/CounterStrikeSharp/releases/download/v1.0.356/counterstrikesharp-with-runtime-linux-1.0.356.zip
+CSSHARP_RELEASE_URL=https://github.com/roflmuffin/CounterStrikeSharp/releases/download/v1.0.361/counterstrikesharp-with-runtime-linux-1.0.361.zip
 
 # Latest matchzy download url can be found from https://github.com/shobhit-pathak/MatchZy/releases (the one without cssharp)
 MATCHZY_RELEASE_URL=https://github.com/shobhit-pathak/MatchZy/releases/download/0.8.15/MatchZy-0.8.15.zip

--- a/cs2/pre.sh
+++ b/cs2/pre.sh
@@ -21,7 +21,7 @@ if ! grep -q "csgo/addons/metamod" ./gameinfo.gi; then
   sed -i 's/^\(\t\t\tGame\tcsgo\)\([^_]\)/\1\/addons\/metamod\r\n\t\t\tGame\tcsgo\2/' ./gameinfo.gi
 fi
 
-sed -i 's/matchzy_minimum_ready_required.*/matchzy_minimum_ready_required 10/' ./cfg/MatchZy/config.cfg
+sed -i 's/matchzy_minimum_ready_required.*/matchzy_minimum_ready_required 0/' ./cfg/MatchZy/config.cfg
 sed -i 's/matchzy_everyone_is_admin.*/matchzy_everyone_is_admin true/' ./cfg/MatchZy/config.cfg
 
 cp /home/steam/gamemodes_server.txt ./gamemodes_server.txt

--- a/cs2/repair.sh
+++ b/cs2/repair.sh
@@ -1,3 +1,4 @@
-mkdir -p data
 docker compose down
+mkdir -p data
+rm -rf data/game/csgo/{cssharp,matchzy}.zip data/game/csgo/metamod.tar.gz
 STEAMAPPVALIDATE=1 docker compose up -d cs2


### PR DESCRIPTION
Remove plugin archives before trying to repair, this forces redownload which is useful if plugin versions are updated on the fly